### PR TITLE
Fix packaging and types

### DIFF
--- a/.changeset/fluffy-hornets-poke.md
+++ b/.changeset/fluffy-hornets-poke.md
@@ -1,0 +1,6 @@
+---
+'@effector/model-react': patch
+'@effector/model': patch
+---
+
+gigi

--- a/apps/food-order/package.json
+++ b/apps/food-order/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "dependencies": {
-    "effector-action": "^1.1.1"
+    "effector-action": "^1.1.3"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^3.1.0",

--- a/apps/tree-todo-list/package.json
+++ b/apps/tree-todo-list/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "dependencies": {
-    "effector-action": "^1.1.1"
+    "effector-action": "^1.1.3"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^3.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effector/model",
   "version": "0.0.7",
-  "type": "commonjs",
+  "type": "module",
   "peerDependencies": {
     "effector": "^23.3.0"
   }

--- a/packages/core/src/instanceApi.ts
+++ b/packages/core/src/instanceApi.ts
@@ -30,7 +30,12 @@ export function createInstanceApi<Input, Enriched, Output, Api, Shape>(
       api[prop] = evt;
       $entities.on(evt, (state, payload) => {
         const [key, data] = Array.isArray(payload.key)
-          ? [payload.key, payload.data]
+          ? [
+              payload.key,
+              Array.isArray(payload.data)
+                ? payload.data
+                : Array.from({ length: payload.key.length }),
+            ]
           : [[payload.key], [payload.data]];
         const targets = [] as any[];
         const params = [] as any[];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -190,18 +190,28 @@ export type ConvertToLensShape<Shape> = {
 
 type OneOrMany<T> = T | Array<T>;
 
+type ApiEvent<T> = void extends T
+  ?
+      | { key: string | number; data?: void }
+      | {
+          key: Array<string | number>;
+          data?: void[];
+        }
+  :
+      | { key: string | number; data: T }
+      | {
+          key: Array<string | number>;
+          data: T[];
+        };
+
 export type Keyval<Input, Enriched, Api, Shape> = {
   type: 'keyval';
   api: {
     [K in keyof Api]: Api[K] extends EventCallable<infer V>
-      ? EventCallable<
-          | { key: string | number; data: V }
-          | {
-              key: Array<string | number>;
-              data: V[];
-            }
-        >
-      : never;
+      ? EventCallable<ApiEvent<V>>
+      : Api[K] extends Effect<infer V, any, any>
+        ? EventCallable<ApiEvent<V>>
+        : never;
   };
   $items: Store<Enriched[]>;
   $keys: Store<Array<string | number>>;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effector/model-react",
   "version": "0.0.7",
-  "type": "commonjs",
+  "type": "module",
   "peerDependencies": {
     "effector": "^23.3.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,8 +220,8 @@ importers:
   apps/food-order:
     dependencies:
       effector-action:
-        specifier: ^1.1.1
-        version: 1.1.1(effector@23.3.0)(patronum@2.3.0(effector@23.3.0))
+        specifier: ^1.1.3
+        version: 1.1.3(effector@23.3.0)(patronum@2.3.0(effector@23.3.0))
     devDependencies:
       '@vitejs/plugin-react':
         specifier: ^3.1.0
@@ -258,8 +258,8 @@ importers:
   apps/tree-todo-list:
     dependencies:
       effector-action:
-        specifier: ^1.1.1
-        version: 1.1.1(effector@23.3.0)(patronum@2.3.0(effector@23.3.0))
+        specifier: ^1.1.3
+        version: 1.1.3(effector@23.3.0)(patronum@2.3.0(effector@23.3.0))
     devDependencies:
       '@vitejs/plugin-react':
         specifier: ^3.1.0
@@ -3097,8 +3097,8 @@ packages:
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
-  effector-action@1.1.1:
-    resolution: {integrity: sha512-CnSDv46aOb/0mCiJ93m49ug+/2Fl+lpH1xMNFCFg/HHfZBsROgfXX1iQKko4/YsDoLakytQBXq4nbiwGszNkuQ==}
+  effector-action@1.1.3:
+    resolution: {integrity: sha512-3YsfaRDP9Y/VF7/vn7DmNmztzz0QlqLK9scdag7oyQ6e3Df6aWako+2FfC9k0NT7dHtLhOo4lJR20zePWEW6IQ==}
     peerDependencies:
       effector: '>=23'
       patronum: '>=2.1.0'
@@ -10293,7 +10293,7 @@ snapshots:
 
   duplexer@0.1.2: {}
 
-  effector-action@1.1.1(effector@23.3.0)(patronum@2.3.0(effector@23.3.0)):
+  effector-action@1.1.3(effector@23.3.0)(patronum@2.3.0(effector@23.3.0)):
     dependencies:
       effector: 23.3.0
       patronum: 2.3.0(effector@23.3.0)
@@ -12643,13 +12643,13 @@ snapshots:
     dependencies:
       htmlparser2: 3.10.1
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-scss@2.1.1)(postcss@7.0.39)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-scss@2.1.1)(postcss@7.0.39)
 
   postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39):
     dependencies:
       '@babel/core': 7.25.2
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-scss@2.1.1)(postcss@7.0.39)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-scss@2.1.1)(postcss@7.0.39)
     transitivePeerDependencies:
       - supports-color
 
@@ -12668,7 +12668,7 @@ snapshots:
   postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39):
     dependencies:
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-scss@2.1.1)(postcss@7.0.39)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-scss@2.1.1)(postcss@7.0.39)
       remark: 10.0.1
       unist-util-find-all-after: 1.0.5
 
@@ -12874,7 +12874,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 2.8.0
 
-  postcss-syntax@0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-scss@2.1.1)(postcss@7.0.39):
+  postcss-syntax@0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-scss@2.1.1)(postcss@7.0.39):
     dependencies:
       postcss: 7.0.39
     optionalDependencies:
@@ -13865,7 +13865,7 @@ snapshots:
       postcss-sass: 0.3.5
       postcss-scss: 2.1.1
       postcss-selector-parser: 3.1.2
-      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-scss@2.1.1)(postcss@7.0.39)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-jsx@0.36.4)(postcss-less@3.1.4)(postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.41))(postcss@7.0.39))(postcss-scss@2.1.1)(postcss@7.0.39)
       postcss-value-parser: 3.3.1
       resolve-from: 4.0.0
       signal-exit: 3.0.7


### PR DESCRIPTION
`@effector/model`:

- Fix module package type (change from commonjs to esm)
- Add support for effects to `api`
- Allow to omit `data` field when `api` unit is void

`@effector/model-react`:

- Fix module package type (change from commonjs to esm)
